### PR TITLE
fix: re-add layer on source reload

### DIFF
--- a/src/runtime/components/Layer.vue
+++ b/src/runtime/components/Layer.vue
@@ -62,8 +62,6 @@ const sourceExists = computed(() => {
 useMapbox(mapId, (map) => {
     function addLayer() {
         if (!sourceExists.value) {
-            // This causes layer to be reloaded whenever the source is.
-            whenever(sourceExists, addLayer);
             return;
         }
         if (props.beforeLayer && map.getLayer(props.beforeLayer)) {
@@ -79,6 +77,8 @@ useMapbox(mapId, (map) => {
     }
 
     addLayer();
+    // This causes layer to be reloaded whenever the source is.
+    whenever(sourceExists, addLayer);
 });
 
 watch(() => props.layer, (newLayer, oldLayer) => {


### PR DESCRIPTION
as discussed in #95 this simple change should make layers persistent for all edge cases

logic before: if source does not exist, addLayer whenever source is being reloaded (ex. on map style change)
logic now: addLayer whenever source is being reloaded