### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/components/CustomGeocoder.vue
+++ b/src/runtime/components/CustomGeocoder.vue
@@ -5,7 +5,7 @@ import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
 import type { GeocoderOptions, Result } from '@mapbox/mapbox-gl-geocoder';
 
 async function initGeocoder() {
-    if (process.client) {
+    if (import.meta.client) {
         //@ts-ignore TODO: Get geocoder module import working
         const MapboxGeocoder = await import('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js');
         initMapbox();

--- a/src/runtime/components/Geocoder.vue
+++ b/src/runtime/components/Geocoder.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 }>();
 
 async function initGeocoder() {
-    if (process.client) {
+    if (import.meta.client) {
         //@ts-ignore TODO: Get geocoder module import working
         const MapboxGeocoder = await import('https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js');
         initMapbox();

--- a/src/runtime/composables/defineMapboxMarker.ts
+++ b/src/runtime/composables/defineMapboxMarker.ts
@@ -32,7 +32,7 @@ export function defineMapboxMarker(markerID: string,
 
 //TODO: MutationObserver on html so it is reactive
 export function defineMapboxMarker(markerID: string, options: MarkerOptions & { lnglat: mapboxgl.LngLatLike } | Ref<MarkerOptions & { lnglat: mapboxgl.LngLatLike }>, markerHTML?: Ref<HTMLElement | null> | undefined, callback?: Function, mapID: string = ""): any {
-    if (process.server) return;
+    if (import.meta.server) return;
 
     if (useMapboxMarkerRef(markerID).value) {
         console.warn(`Mapbox marker with ID '${markerID}' was initialized multiple times. This can cause unexpected behaviour.`);

--- a/src/runtime/composables/defineMapboxPopup.ts
+++ b/src/runtime/composables/defineMapboxPopup.ts
@@ -12,7 +12,7 @@ import { type MapboxPopupsObject } from '../../module';
  */
 export function defineMapboxPopup(popupID: string, options: PopupOptions | Ref<PopupOptions>, popupHTML: Ref<HTMLElement | null> = ref(null), mapID: string = ""): Popup | undefined {
     const mapId = inject<string>('MapID')
-    if (process.server) return;
+    if (import.meta.server) return;
 
     if (useMapboxPopupRef(popupID).value) {
         console.warn(`Mapbox marker with ID '${popupID}' was initialized multiple times. This can cause unexpected behaviour.`);

--- a/src/runtime/composables/initMapbox.ts
+++ b/src/runtime/composables/initMapbox.ts
@@ -5,7 +5,7 @@ import type { ExtendedRuntimeConfig } from '../../module';
 import { useRuntimeConfig } from '#imports'
 
 export function initMapbox() {
-    if (process.server) return;
+    if (import.meta.server) return;
 
     const init = useState('mapbox_init', () => false);
     if (init.value) return;

--- a/src/runtime/composables/mapboxInstances.ts
+++ b/src/runtime/composables/mapboxInstances.ts
@@ -4,5 +4,5 @@ import { useState } from "#imports";
 
 export function _useMapboxInstances(): Ref<MapboxInstancesObject> | undefined {
     // TODO: Move to pinia? Would have better debugger support.
-    return process.server ? undefined : useState('mapbox_instances', () => ({}));
+    return import.meta.server ? undefined : useState('mapbox_instances', () => ({}));
 }


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)