### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 
 ```bash
 npx nuxi@latest module add nuxt-mapbox
+npm install --save-dev mapbox-gl
 ```
 
 2. Add `nuxt-mapbox` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -29,14 +29,7 @@
 1. Add `nuxt-mapbox` & `mapbox-gl` dependencies to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-mapbox mapbox-gl
-
-# Using yarn
-yarn add --dev nuxt-mapbox mapbox-gl
-
-# Using npm
-npm install --save-dev nuxt-mapbox mapbox-gl
+npx nuxi@latest module add nuxt-mapbox
 ```
 
 2. Add `nuxt-mapbox` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/1.getting-started/1.quick-setup.md
+++ b/docs/content/1.getting-started/1.quick-setup.md
@@ -1,22 +1,9 @@
 # Quick Setup
 
 1. Add `nuxt-mapbox` & `mapbox-gl` dependencies to your project
-
-::code-group
-
-  ```bash [pnpm]
-  pnpm add -D nuxt-mapbox mapbox-gl
-  ```
-
-  ```bash [yarn]
-  yarn add --dev nuxt-mapbox mapbox-gl
-  ```
-
-  ```bash [npm]
-  npm install --save-dev nuxt-mapbox mapbox-gl
-  ```
-
-::
+```bash
+npx nuxi@latest module add nuxt-mapbox
+```
 
 2. Add `nuxt-mapbox` to the `modules` section of `nuxt.config.ts`
 

--- a/docs/content/1.getting-started/1.quick-setup.md
+++ b/docs/content/1.getting-started/1.quick-setup.md
@@ -3,6 +3,7 @@
 1. Add `nuxt-mapbox` & `mapbox-gl` dependencies to your project
 ```bash
 npx nuxi@latest module add nuxt-mapbox
+npm install --save-dev mapbox-gl
 ```
 
 2. Add `nuxt-mapbox` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
