### PR TITLE
Update Geocoder.vue to satisfy type constraints

### DIFF
--- a/src/runtime/components/Geocoder.vue
+++ b/src/runtime/components/Geocoder.vue
@@ -57,11 +57,11 @@ if (mapId) {
             emit("loading", q);
         });
         geocoder.on('results', (r) => {
-            emit("results", r);
+            emit("results", r.features);
         });
         geocoder.on('result', (r) => {
             emit("update:modelValue", r.result);
-            emit("result", r);
+            emit("result", r.result);
         });
         geocoder.on('error', (e) => {
             emit("error", e);


### PR DESCRIPTION
* Unwrap property `result` from geocoding results when emitting Geocoder.vue's `result` event.
* Unwrap property `features` from geocoding results when emitting Geocoder.vue's `results` event.

Fix https://github.com/AlexLavoie42/Nuxt-Mapbox/issues/121