### PR TITLE
Fix map flickering on resize

### DIFF
--- a/src/runtime/components/Map.vue
+++ b/src/runtime/components/Map.vue
@@ -185,7 +185,7 @@ onMounted(() => {
     }
 
     useResizeObserver(mapContainerRef, () => {
-        map.value?.resize()
+        setTimeout(() => map.value?.resize(), 0)
     })
 });
 


### PR DESCRIPTION
Defer execution of resize using set timeout 0 to avoid map flickering.

Ref: https://stackoverflow.com/questions/70533564/mapbox-gl-flickers-when-resizing-the-container-div#comment132626298_70533564


The issue:

https://github.com/user-attachments/assets/98ea04f8-3352-4707-ad78-bcddd9afef7c



Using `setTimeout(() => map.value?.resize(), 0)`:

https://github.com/user-attachments/assets/4ca29b21-d615-427d-8206-34f3b2298948

